### PR TITLE
Compatibility changes for non-unity building

### DIFF
--- a/Source/Plugins/NodeGraphAssistant/Source/Private/ConnectionDrawingPolicy/NGAAnimGraphConnectionDrawingPolicy.cpp
+++ b/Source/Plugins/NodeGraphAssistant/Source/Private/ConnectionDrawingPolicy/NGAAnimGraphConnectionDrawingPolicy.cpp
@@ -3,6 +3,12 @@
 
 #include "NGAAnimGraphConnectionDrawingPolicy.h"
 
+#ifdef NGA_WITH_ENGINE_CPP
+#include "AnimGraphConnectionDrawingPolicy.cpp"
+#else
+#include "../EngineCppFiles/AnimGraphConnectionDrawingPolicy.cpp"
+#endif
+
 
 void FNGAAnimGraphConnectionDrawingPolicy::DrawPreviewConnector(const FGeometry& PinGeometry, const FVector2D& StartPoint, const FVector2D& EndPoint, UEdGraphPin* Pin)
 {

--- a/Source/Plugins/NodeGraphAssistant/Source/Private/ConnectionDrawingPolicy/NGAAnimGraphConnectionDrawingPolicy.h
+++ b/Source/Plugins/NodeGraphAssistant/Source/Private/ConnectionDrawingPolicy/NGAAnimGraphConnectionDrawingPolicy.h
@@ -4,12 +4,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-
-#ifdef NGA_WITH_ENGINE_CPP
-	#include "AnimGraphConnectionDrawingPolicy.cpp"
-#else
-	#include "../EngineCppFiles/AnimGraphConnectionDrawingPolicy.cpp"
-#endif
+#include "AnimGraphConnectionDrawingPolicy.h"
 
 #include "NGAGraphConnectionDrawingPolicyCommon.h"
 

--- a/Source/Plugins/NodeGraphAssistant/Source/Private/ConnectionDrawingPolicy/NGAMaterialGraphConnectionDrawingPolicy.cpp
+++ b/Source/Plugins/NodeGraphAssistant/Source/Private/ConnectionDrawingPolicy/NGAMaterialGraphConnectionDrawingPolicy.cpp
@@ -3,6 +3,12 @@
 
 #include "NGAMaterialGraphConnectionDrawingPolicy.h"
 
+#ifdef NGA_WITH_ENGINE_CPP
+#include "MaterialGraphConnectionDrawingPolicy.cpp"
+#else
+#include "../EngineCppFiles/MaterialGraphConnectionDrawingPolicy.cpp"
+#endif
+
 
 void FNGAMaterialGraphConnectionDrawingPolicy::DrawPreviewConnector(const FGeometry& PinGeometry, const FVector2D& StartPoint, const FVector2D& EndPoint, UEdGraphPin* Pin)
 {

--- a/Source/Plugins/NodeGraphAssistant/Source/Private/ConnectionDrawingPolicy/NGAMaterialGraphConnectionDrawingPolicy.h
+++ b/Source/Plugins/NodeGraphAssistant/Source/Private/ConnectionDrawingPolicy/NGAMaterialGraphConnectionDrawingPolicy.h
@@ -4,12 +4,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-
-#ifdef NGA_WITH_ENGINE_CPP
-	#include "MaterialGraphConnectionDrawingPolicy.cpp"
-#else
-	#include "../EngineCppFiles/MaterialGraphConnectionDrawingPolicy.cpp"
-#endif
+#include "MaterialGraphConnectionDrawingPolicy.h"
 
 #include "NGAGraphConnectionDrawingPolicyCommon.h"
 

--- a/Source/Plugins/NodeGraphAssistant/Source/Private/ConnectionDrawingPolicy/NGASoundCueConnectionDrawingPolicy.cpp
+++ b/Source/Plugins/NodeGraphAssistant/Source/Private/ConnectionDrawingPolicy/NGASoundCueConnectionDrawingPolicy.cpp
@@ -3,6 +3,12 @@
 
 #include "NGASoundCueConnectionDrawingPolicy.h"
 
+#ifdef NGA_WITH_ENGINE_CPP
+#include "SoundCueGraphConnectionDrawingPolicy.cpp"
+#else
+#include "../EngineCppFiles/SoundCueGraphConnectionDrawingPolicy.cpp"
+#endif
+
 
 void FNGASoundCueGraphConnectionDrawingPolicy::DrawPreviewConnector(const FGeometry& PinGeometry, const FVector2D& StartPoint, const FVector2D& EndPoint, UEdGraphPin* Pin)
 {

--- a/Source/Plugins/NodeGraphAssistant/Source/Private/ConnectionDrawingPolicy/NGASoundCueConnectionDrawingPolicy.h
+++ b/Source/Plugins/NodeGraphAssistant/Source/Private/ConnectionDrawingPolicy/NGASoundCueConnectionDrawingPolicy.h
@@ -5,12 +5,7 @@
 
 #include "CoreMinimal.h"
 #include "SoundCueGraph/SoundCueGraphSchema.h"
-
-#ifdef NGA_WITH_ENGINE_CPP
-	#include "SoundCueGraphConnectionDrawingPolicy.cpp"
-#else
-	#include "../EngineCppFiles/SoundCueGraphConnectionDrawingPolicy.cpp"
-#endif
+#include "SoundCueGraphConnectionDrawingPolicy.h"
 
 #include "NGAGraphConnectionDrawingPolicyCommon.h"
 

--- a/Source/Plugins/NodeGraphAssistant/Source/Private/NGAGraphPinConnectionFactory.cpp
+++ b/Source/Plugins/NodeGraphAssistant/Source/Private/NGAGraphPinConnectionFactory.cpp
@@ -20,6 +20,7 @@
 #include "EngineCppFiles/SGraphNodeAnimTransition.cpp"
 #endif
 
+#include "AnimationGraphSchema.h"
 #include "Version.h"
 
 

--- a/Source/Plugins/NodeGraphAssistant/Source/Private/NGAInputProcessor.cpp
+++ b/Source/Plugins/NodeGraphAssistant/Source/Private/NGAInputProcessor.cpp
@@ -409,7 +409,7 @@ void NGAInputProcessor::CancelDraggingReset(int32 UserIndex)
 		slateApp.CancelDragDrop();
 		LocalDragDropContent->OnDrop(true, FPointerEvent());
 	}
-	slateApp.ReleaseMouseCaptureForUser(UserIndex);
+	slateApp.ReleaseAllPointerCapture(UserIndex);
 	slateApp.GetPlatformApplication()->SetCapture(nullptr);
 	if (slateApp.GetPlatformCursor().IsValid())
 	{
@@ -704,7 +704,7 @@ FNGAEventReply NGAInputProcessor::TryProcessAsEndDragNPanEvent(FSlateApplication
 		{
 			if (!Ctx.IsClickGesture)
 			{
-				SlateApp.ReleaseMouseCaptureForUser(MouseEvent.GetUserIndex());
+				SlateApp.ReleaseAllPointerCapture(MouseEvent.GetUserIndex());
 				if (SlateApp.GetPlatformCursor().IsValid())
 				{
 					SlateApp.GetPlatformCursor()->Show(true);
@@ -836,7 +836,7 @@ FNGAEventReply NGAInputProcessor::TryProcessAsMultiConnectEvent(FSlateApplicatio
 				if (Ctx.GraphPin.IsValid())
 				{
 					Ctx.GraphPin->OnDrop(Ctx.PinGeometry, FDragDropEvent(MouseEvent, dragConnection));
-					SlateApp.ReleaseMouseCaptureForUser(MouseEvent.GetUserIndex());
+					SlateApp.ReleaseAllPointerCapture(MouseEvent.GetUserIndex());
 					return FNGAEventReply::BlockSlateInput();
 				}
 			}
@@ -1067,7 +1067,7 @@ FNGAEventReply NGAInputProcessor::TryProcessAsSingleHighlightEvent(FSlateApplica
 					}
 
 					//click on wire will create mouse capture,causing graph pin to be not clickable at first click,so release capture.
-					SlateApp.ReleaseMouseCaptureForUser(MouseEvent.GetUserIndex());
+					SlateApp.ReleaseAllPointerCapture(MouseEvent.GetUserIndex());
 					SlateApp.GetPlatformApplication()->SetCapture(nullptr);
 					return FNGAEventReply::BlockSlateInput();
 				}
@@ -1227,7 +1227,7 @@ FNGAEventReply NGAInputProcessor::TryProcessAsEndCutOffWireEvent(FSlateApplicati
 			HasBegunCuttingWire = false;
 
 			MyPinFactory->PayLoadData->CursorDeltaSquared = 0;
-			SlateApp.ReleaseMouseCaptureForUser(MouseEvent.GetUserIndex());
+			SlateApp.ReleaseAllPointerCapture(MouseEvent.GetUserIndex());
 			SlateApp.GetPlatformApplication()->SetCapture(nullptr);
 
 			if (GEditor && GEditor->Trans && !GEditor->bIsSimulatingInEditor)
@@ -1511,7 +1511,7 @@ FNGAEventReply NGAInputProcessor::TryProcessAsCreateNodeOnWireEvent(FSlateApplic
 			}, tryTimes);
 			TickEventListener.Add(deferredDele);
 
-			SlateApp.ReleaseMouseCaptureForUser(MouseEvent.GetUserIndex());
+			SlateApp.ReleaseAllPointerCapture(MouseEvent.GetUserIndex());
 			SlateApp.GetPlatformApplication()->SetCapture(nullptr);
 
 			return FNGAEventReply::BlockSlateInput();

--- a/Source/Plugins/NodeGraphAssistant/Source/Private/NodeGraphAssistantCommands.h
+++ b/Source/Plugins/NodeGraphAssistant/Source/Private/NodeGraphAssistantCommands.h
@@ -40,7 +40,7 @@ public:
 
 #define LOCTEXT_NAMESPACE "FNodeGraphAssistantCommands"
 
-void FNodeGraphAssistantCommands::RegisterCommands()
+inline void FNodeGraphAssistantCommands::RegisterCommands()
 {
 	UI_COMMAND(RearrangeNode, "Rearrange Nodes", "Rearrange Nodes into grid structure", EUserInterfaceActionType::Button, FInputChord(EKeys::R, false, false, true, false));
 	UI_COMMAND(BypassNodes, "Bypass Nodes", "Disconnect selected nodes from outside connections while maintain connetion flow,delete selected nodes if fully bypassed.", EUserInterfaceActionType::Button, FInputChord(EKeys::X, false, false, true, false));


### PR DESCRIPTION
As title says, originally when the UE4 target is set to not to use unity-build (bUseUnityBuild = false;), this plugin throws some linking errors, originally caused by including source files in headers which were then included in other headers/sources. See comments in commits.